### PR TITLE
T2D-251 Updateddl and db

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
     productionHost = credentials('PRODUCTIONHOST')
   }
   parameters {
-    choice(choices: ['validate', 'update','create'], description: 'Behaviour at connection time for staging  only \
-    (initialize/update/validate schema)', name: 'dbBehaviour')
+    choice(choices: ['validate', 'update','create'], description: 'Behaviour at connection time for staging only \
+           (initialize/update/validate schema)', name: 'dbBehaviour')
     booleanParam(name: 'DeployToStaging' , defaultValue: false , description: '')
     booleanParam(name: 'DeployToProduction' , defaultValue: false , description: '')
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     productionHost = credentials('PRODUCTIONHOST')
   }
   parameters {
-    choice(choices: ['validate', 'update','create'], description: 'Behaviour at connection time for staging  only
+    choice(choices: ['validate', 'update','create'], description: 'Behaviour at connection time for staging  only \
     (initialize/update/validate schema)', name: 'dbBehaviour')
     booleanParam(name: 'DeployToStaging' , defaultValue: false , description: '')
     booleanParam(name: 'DeployToProduction' , defaultValue: false , description: '')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,13 +16,17 @@ pipeline {
     productionHost = credentials('PRODUCTIONHOST')
   }
   parameters {
+    choice(choices: ['validate', 'create'], description: 'Behaviour at connection time (initialize/validate schema)',
+          name: 'dbBehaviour')
     booleanParam(name: 'DeployToStaging' , defaultValue: false , description: '')
     booleanParam(name: 'DeployToProduction' , defaultValue: false , description: '')
   }
   stages {
     stage('Default Build pointing to Staging DB') {
       steps {
-        sh "mvn clean package -DskipTests -DbuildDirectory=staging/target -Dmetadata-dbUrl=${stagingPostgresDbUrl} -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword}"
+        sh "mvn clean package -DskipTests -DbuildDirectory=staging/target -Dmetadata-dbUrl=${stagingPostgresDbUrl}
+        -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword}
+        -Dmetadata-ddlBehaviour=${dbBehaviour}"
       }
     }
     stage('Build For FallBack And Production') {
@@ -33,9 +37,11 @@ pipeline {
       }
       steps {
         echo 'Build pointing to FallBack DB'
-        sh "mvn clean package -DskipTests -DbuildDirectory=fallback/target -Dmetadata-dbUrl=${fallBackPostgresDbUrl} -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword}"
+        sh "mvn clean package -DskipTests -DbuildDirectory=fallback/target -Dmetadata-dbUrl=${fallBackPostgresDbUrl}
+        -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword} -Dmetadata-ddlBehaviour=${dbBehaviour}"
         echo 'Build pointing to Production DB'
-        sh "mvn clean package -DskipTests -DbuildDirectory=production/target -Dmetadata-dbUrl=${productionPostgresDbUrl} -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword}"
+        sh "mvn clean package -DskipTests -DbuildDirectory=production/target
+        -Dmetadata-dbUrl=${productionPostgresDbUrl} -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword} -Dmetadata-ddlBehaviour=${dbBehaviour}"
       }
     }
     stage('Deploy To Staging') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,8 @@ pipeline {
   }
   environment {
     stagingPostgresDbUrl = credentials('STAGINGMETADATAWSDBURL')
-    fallBackPostgresDbUrl = credentials('STAGINGMETADATAWSDBURL')
-    productionPostgresDbUrl = credentials('STAGINGMETADATAWSDBURL')
+    fallBackPostgresDbUrl = credentials('FALLBACKMETADATAWSDBURL')
+    productionPostgresDbUrl = credentials('PRODMETADATAWSDBURL')
     postgresDBUserName = credentials('POSTGRESDBUSERNAME')
     postgresDBPassword = credentials('POSTGRESDBPASSWORD')
     tomcatCredentials = credentials('TOMCATCREDENTIALS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
     productionHost = credentials('PRODUCTIONHOST')
   }
   parameters {
-    choice(choices: ['validate', 'create'], description: 'Behaviour at connection time (initialize/validate schema)',
-     name: 'dbBehaviour')
+    choice(choices: ['validate', 'update','create'], description: 'Behaviour at connection time for staging  only
+    (initialize/update/validate schema)', name: 'dbBehaviour')
     booleanParam(name: 'DeployToStaging' , defaultValue: false , description: '')
     booleanParam(name: 'DeployToProduction' , defaultValue: false , description: '')
   }
@@ -39,11 +39,11 @@ pipeline {
         echo 'Build pointing to FallBack DB'
         sh "mvn clean package -DskipTests -DbuildDirectory=fallback/target -Dmetadata-dbUrl=${fallBackPostgresDbUrl} \
          -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword}  \
-        -Dmetadata-ddlBehaviour=${dbBehaviour}"
+        -Dmetadata-ddlBehaviour=validate"
         echo 'Build pointing to Production DB'
         sh "mvn clean package -DskipTests -DbuildDirectory=production/target \
         -Dmetadata-dbUrl=${productionPostgresDbUrl} -Dmetadata-dbUsername=${postgresDBUserName} \
-        -Dmetadata-dbPassword=${postgresDBPassword} -Dmetadata-ddlBehaviour=${dbBehaviour}"
+        -Dmetadata-dbPassword=${postgresDBPassword} -Dmetadata-ddlBehaviour=validate"
       }
     }
     stage('Deploy To Staging') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,15 +16,14 @@ pipeline {
     productionHost = credentials('PRODUCTIONHOST')
   }
   parameters {
-    choice(choices: ['validate', 'create'], description: 'Behaviour at connection time (initialize/validate schema)',
-          name: 'dbBehaviour')
+    choice(choices: ['validate', 'create'], description: 'Behaviour at connection time (initialize/validate schema)',name: 'dbBehaviour')
     booleanParam(name: 'DeployToStaging' , defaultValue: false , description: '')
     booleanParam(name: 'DeployToProduction' , defaultValue: false , description: '')
   }
   stages {
     stage('Default Build pointing to Staging DB') {
       steps {
-        sh "mvn clean package -DskipTests -DbuildDirectory=staging/target -Dmetadata-dbUrl=${stagingPostgresDbUrl}
+        sh "mvn clean package -DskipTests -DbuildDirectory=staging/target -Dmetadata-dbUrl=${stagingPostgresDbUrl} \
         -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword}
         -Dmetadata-ddlBehaviour=${dbBehaviour}"
       }
@@ -37,10 +36,10 @@ pipeline {
       }
       steps {
         echo 'Build pointing to FallBack DB'
-        sh "mvn clean package -DskipTests -DbuildDirectory=fallback/target -Dmetadata-dbUrl=${fallBackPostgresDbUrl}
+        sh "mvn clean package -DskipTests -DbuildDirectory=fallback/target -Dmetadata-dbUrl=${fallBackPostgresDbUrl} \
         -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword} -Dmetadata-ddlBehaviour=${dbBehaviour}"
         echo 'Build pointing to Production DB'
-        sh "mvn clean package -DskipTests -DbuildDirectory=production/target
+        sh "mvn clean package -DskipTests -DbuildDirectory=production/target \
         -Dmetadata-dbUrl=${productionPostgresDbUrl} -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword} -Dmetadata-ddlBehaviour=${dbBehaviour}"
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
   }
   parameters {
     choice(choices: ['validate', 'update','create'], description: 'Behaviour at connection time for staging only \
-           (initialize/update/validate schema)', name: 'dbBehaviour')
+           (initialize/update/validate schema)', name: 'ddlBehaviour')
     booleanParam(name: 'DeployToStaging' , defaultValue: false , description: '')
     booleanParam(name: 'DeployToProduction' , defaultValue: false , description: '')
   }
@@ -26,7 +26,7 @@ pipeline {
       steps {
         sh "mvn clean package -DskipTests -DbuildDirectory=staging/target -Dmetadata-dbUrl=${stagingPostgresDbUrl} \
         -Dmetadata-dbUsername=${postgresDBUserName} -Dmetadata-dbPassword=${postgresDBPassword} \
-        -Dmetadata-ddlBehaviour=${dbBehaviour}"
+        -Dmetadata-ddlBehaviour=${ddlBehaviour}"
       }
     }
     stage('Build For FallBack And Production') {

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4-1206-jdbc42</version>
+            <version>42.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -87,25 +87,25 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-data-rest</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-bean-validators</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.2</version>
         </dependency>
     </dependencies>
-    
+
     <build>
         <directory>${buildDirectory}</directory>
         <plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,7 @@ endpoints.health.sensitive=false
 spring.datasource.url=@metadata-dbUrl@
 spring.datasource.username=@metadata-dbUsername@
 spring.datasource.password=@metadata-dbPassword@
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=@metadata-ddlBehaviour@
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.generate-ddl=true
 


### PR DESCRIPTION
RIght now as the ddl is validate , every time there is a change in schema we need to change the ddl to create and run the application locally to create the tables fresh, and then change the ddl to validate when deploying to envs. 
So to avoid the above manual create in local , we have to include a option while deploying to envs (create and validate) .