### PR TITLE
T2D-291 — Store Sample in metadata

### DIFF
--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/ObjectsImporter.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/ObjectsImporter.java
@@ -153,6 +153,8 @@ public abstract class ObjectsImporter {
         return study;
     }
 
+    protected abstract Study extractAnalysisFromStudy(StudyType studyType, Study study);
+
     public Analysis importAnalysis(String accession) {
         Analysis analysis = null;
         try {
@@ -179,6 +181,8 @@ public abstract class ObjectsImporter {
         return analysis;
     }
 
+    protected abstract Analysis extractStudyFromAnalysis(AnalysisType analysisType, Analysis analysis);
+
     public ReferenceSequence importReferenceSequence(String accession) {
         ReferenceSequence referenceSequence = null;
         try {
@@ -194,26 +198,6 @@ public abstract class ObjectsImporter {
         }
         return referenceSequence;
     }
-
-    public Sample importSample(String accession) {
-        Sample sample = null;
-        try {
-            String xml = sraXmlRetrieverByAccession.getXml(accession);
-            SampleType sampleType = sraSampleXmlParser.parseXml(xml, accession);
-            sample = sampleConverter.convert(sampleType);
-            Taxonomy taxonomy = taxonomyRepository.findOrSave(extractTaxonomyFromSample(sampleType));
-            sample.setTaxonomies(Arrays.asList(taxonomy));
-            sample = sampleRepository.findOrSave(sample);
-        } catch (Exception exception) {
-            IMPORT_LOGGER.log(Level.SEVERE, "Encountered Exception for Sample accession " + accession);
-            IMPORT_LOGGER.log(Level.SEVERE, exception.getMessage());
-        }
-        return sample;
-    }
-
-    protected abstract Study extractAnalysisFromStudy(StudyType studyType, Study study);
-
-    protected abstract Analysis extractStudyFromAnalysis(AnalysisType analysisType, Analysis analysis);
 
     protected String getAccessionFromStandard(ReferenceAssemblyType.STANDARD standard) {
         return standard.getAccession();
@@ -262,6 +246,22 @@ public abstract class ObjectsImporter {
             }
         }
         return null;
+    }
+
+    public Sample importSample(String accession) {
+        Sample sample = null;
+        try {
+            String xml = sraXmlRetrieverByAccession.getXml(accession);
+            SampleType sampleType = sraSampleXmlParser.parseXml(xml, accession);
+            sample = sampleConverter.convert(sampleType);
+            Taxonomy taxonomy = taxonomyRepository.findOrSave(extractTaxonomyFromSample(sampleType));
+            sample.setTaxonomies(Arrays.asList(taxonomy));
+            sample = sampleRepository.findOrSave(sample);
+        } catch (Exception exception) {
+            IMPORT_LOGGER.log(Level.SEVERE, "Encountered Exception for Sample accession " + accession);
+            IMPORT_LOGGER.log(Level.SEVERE, exception.getMessage());
+        }
+        return sample;
     }
 
     private Taxonomy extractTaxonomyFromSample(SampleType sampleType) {

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/ObjectsImporter.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/ObjectsImporter.java
@@ -153,8 +153,6 @@ public abstract class ObjectsImporter {
         return study;
     }
 
-    protected abstract Study extractAnalysisFromStudy(StudyType studyType, Study study);
-
     public Analysis importAnalysis(String accession) {
         Analysis analysis = null;
         try {
@@ -181,8 +179,6 @@ public abstract class ObjectsImporter {
         return analysis;
     }
 
-    protected abstract Analysis extractStudyFromAnalysis(AnalysisType analysisType, Analysis analysis);
-
     public ReferenceSequence importReferenceSequence(String accession) {
         ReferenceSequence referenceSequence = null;
         try {
@@ -197,6 +193,30 @@ public abstract class ObjectsImporter {
             IMPORT_LOGGER.log(Level.SEVERE, exception.getMessage());
         }
         return referenceSequence;
+    }
+
+    public Sample importSample(String accession) {
+        Sample sample = null;
+        try {
+            String xml = sraXmlRetrieverByAccession.getXml(accession);
+            SampleType sampleType = sraSampleXmlParser.parseXml(xml, accession);
+            sample = sampleConverter.convert(sampleType);
+            Taxonomy taxonomy = taxonomyRepository.findOrSave(extractTaxonomyFromSample(sampleType));
+            sample.setTaxonomies(Arrays.asList(taxonomy));
+            sample = sampleRepository.findOrSave(sample);
+        } catch (Exception exception) {
+            IMPORT_LOGGER.log(Level.SEVERE, "Encountered Exception for Sample accession " + accession);
+            IMPORT_LOGGER.log(Level.SEVERE, exception.getMessage());
+        }
+        return sample;
+    }
+
+    protected abstract Study extractAnalysisFromStudy(StudyType studyType, Study study);
+
+    protected abstract Analysis extractStudyFromAnalysis(AnalysisType analysisType, Analysis analysis);
+
+    protected String getAccessionFromStandard(ReferenceAssemblyType.STANDARD standard) {
+        return standard.getAccession();
     }
 
     private Taxonomy extractTaxonomyFromAssembly(AssemblyType assemblyType) {
@@ -242,26 +262,6 @@ public abstract class ObjectsImporter {
             }
         }
         return null;
-    }
-
-    protected String getAccessionFromStandard(ReferenceAssemblyType.STANDARD standard) {
-        return standard.getAccession();
-    }
-
-    public Sample importSample(String accession) {
-        Sample sample = null;
-        try {
-            String xml = sraXmlRetrieverByAccession.getXml(accession);
-            SampleType sampleType = sraSampleXmlParser.parseXml(xml, accession);
-            sample = sampleConverter.convert(sampleType);
-            Taxonomy taxonomy = taxonomyRepository.findOrSave(extractTaxonomyFromSample(sampleType));
-            sample.setTaxonomies(Arrays.asList(taxonomy));
-            sample = sampleRepository.findOrSave(sample);
-        } catch (Exception exception) {
-            IMPORT_LOGGER.log(Level.SEVERE, "Encountered Exception for Sample accession " + accession);
-            IMPORT_LOGGER.log(Level.SEVERE, exception.getMessage());
-        }
-        return sample;
     }
 
     private Taxonomy extractTaxonomyFromSample(SampleType sampleType) {

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/ObjectsImporter.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/ObjectsImporter.java
@@ -29,6 +29,7 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Study;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.repositories.SampleRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Taxonomy;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.TaxonomyRepository;
@@ -36,9 +37,11 @@ import uk.ac.ebi.ena.sra.xml.AnalysisType;
 import uk.ac.ebi.ena.sra.xml.AssemblyType;
 import uk.ac.ebi.ena.sra.xml.ReferenceAssemblyType;
 import uk.ac.ebi.ena.sra.xml.ReferenceSequenceType;
+import uk.ac.ebi.ena.sra.xml.SampleType;
 import uk.ac.ebi.ena.sra.xml.StudyType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,62 +52,88 @@ public abstract class ObjectsImporter {
 
     private static final Logger IMPORT_LOGGER = Logger.getLogger(ObjectsImporter.class.getName());
 
+    // Common XML retriever for all entities
     protected SraXmlRetrieverByAccession sraXmlRetrieverByAccession;
 
+    // Entity repositories
     protected StudyRepository studyRepository;
 
     protected AnalysisRepository analysisRepository;
 
     protected ReferenceSequenceRepository referenceSequenceRepository;
 
+    protected SampleRepository sampleRepository;
+
     protected TaxonomyRepository taxonomyRepository;
 
+    // Entity XML parsers
     private SraXmlParser<StudyType> sraStudyXmlParser;
 
     private SraXmlParser<AnalysisType> sraAnalysisXmlParser;
 
     private SraXmlParser<AssemblyType> sraAssemblyXmlParser;
 
+    private SraXmlParser<SampleType> sraSampleXmlParser;
+
+    // Entity converters
     private Converter<StudyType, Study> studyConverter;
 
     private Converter<AnalysisType, Analysis> analysisConverter;
 
     private Converter<AssemblyType, ReferenceSequence> referenceSequenceConverter;
 
+    private Converter<SampleType, Sample> sampleConverter;
+
+    // Extractors
     private PublicationExtractorFromStudy publicationExtractorFromStudy;
 
     private WebResourceExtractorFromStudy webResourceExtractorFromStudy;
 
     private FileExtractorFromAnalysis fileExtractorFromAnalysis;
 
-    public ObjectsImporter(SraXmlRetrieverByAccession sraXmlRetrieverByAccession,
-                           SraXmlParser<StudyType> sraStudyXmlParser,
-                           SraXmlParser<AnalysisType> sraAnalysisXmlParser,
-                           SraXmlParser<AssemblyType> sraAssemblyXmlParser,
-                           Converter<StudyType, Study> studyConverter,
-                           Converter<AnalysisType, Analysis> analysisConverter,
-                           Converter<AssemblyType, ReferenceSequence> referenceSequenceConverter,
-                           PublicationExtractorFromStudy publicationExtractorFromStudy,
-                           WebResourceExtractorFromStudy webResourceExtractorFromStudy,
-                           FileExtractorFromAnalysis fileExtractorFromAnalysis,
-                           AnalysisRepository analysisRepository,
-                           StudyRepository studyRepository,
-                           ReferenceSequenceRepository referenceSequenceRepository,
-                           TaxonomyRepository taxonomyRepository) {
+    public ObjectsImporter(
+            SraXmlRetrieverByAccession sraXmlRetrieverByAccession,
+
+            SraXmlParser<StudyType> sraStudyXmlParser,
+            SraXmlParser<AnalysisType> sraAnalysisXmlParser,
+            SraXmlParser<AssemblyType> sraAssemblyXmlParser,
+            SraXmlParser<SampleType> sraSampleXmlParser,
+
+            Converter<StudyType, Study> studyConverter,
+            Converter<AnalysisType, Analysis> analysisConverter,
+            Converter<AssemblyType, ReferenceSequence> referenceSequenceConverter,
+            Converter<SampleType, Sample> sampleConverter,
+
+            PublicationExtractorFromStudy publicationExtractorFromStudy,
+            WebResourceExtractorFromStudy webResourceExtractorFromStudy,
+            FileExtractorFromAnalysis fileExtractorFromAnalysis,
+
+            StudyRepository studyRepository,
+            AnalysisRepository analysisRepository,
+            ReferenceSequenceRepository referenceSequenceRepository,
+            SampleRepository sampleRepository,
+            TaxonomyRepository taxonomyRepository) {
         this.sraXmlRetrieverByAccession = sraXmlRetrieverByAccession;
+
         this.sraStudyXmlParser = sraStudyXmlParser;
         this.sraAnalysisXmlParser = sraAnalysisXmlParser;
         this.sraAssemblyXmlParser = sraAssemblyXmlParser;
+        this.sraSampleXmlParser = sraSampleXmlParser;
+
         this.studyConverter = studyConverter;
         this.analysisConverter = analysisConverter;
         this.referenceSequenceConverter = referenceSequenceConverter;
+        this.sampleConverter = sampleConverter;
+
         this.publicationExtractorFromStudy = publicationExtractorFromStudy;
         this.webResourceExtractorFromStudy = webResourceExtractorFromStudy;
         this.fileExtractorFromAnalysis = fileExtractorFromAnalysis;
-        this.analysisRepository = analysisRepository;
+
         this.studyRepository = studyRepository;
+        this.analysisRepository = analysisRepository;
         this.referenceSequenceRepository = referenceSequenceRepository;
         this.taxonomyRepository = taxonomyRepository;
+        this.sampleRepository = sampleRepository;
     }
 
     public Study importStudy(String accession) {
@@ -140,8 +169,7 @@ public abstract class ObjectsImporter {
             analysis.setReferenceSequences(referenceSequences);
             List<Sample> samples = new ArrayList<>();
             for (String sampleAccession : getSampleAccessions(analysisType)) {
-                //TODO Sample Import
-                //samples.add(importSample(sampleAccession));
+                samples.add(importSample(sampleAccession));
             }
             analysis.setSamples(samples);
             analysis = extractStudyFromAnalysis(analysisType, analysis);
@@ -221,7 +249,24 @@ public abstract class ObjectsImporter {
     }
 
     public Sample importSample(String accession) {
-        return null;
+        Sample sample = null;
+        try {
+            String xml = sraXmlRetrieverByAccession.getXml(accession);
+            SampleType sampleType = sraSampleXmlParser.parseXml(xml, accession);
+            sample = sampleConverter.convert(sampleType);
+            Taxonomy taxonomy = taxonomyRepository.findOrSave(extractTaxonomyFromSample(sampleType));
+            sample.setTaxonomies(Arrays.asList(taxonomy));
+            sample = sampleRepository.findOrSave(sample);
+        } catch (Exception exception) {
+            IMPORT_LOGGER.log(Level.SEVERE, "Encountered Exception for Sample accession " + accession);
+            IMPORT_LOGGER.log(Level.SEVERE, exception.getMessage());
+        }
+        return sample;
+    }
+
+    private Taxonomy extractTaxonomyFromSample(SampleType sampleType) {
+        SampleType.SAMPLENAME sampleName = sampleType.getSAMPLENAME();
+        return new Taxonomy(sampleName.getTAXONID(), sampleName.getSCIENTIFICNAME());
     }
 
     private Set<String> getSampleAccessions(AnalysisType analysisType) {

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPI.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPI.java
@@ -30,11 +30,13 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Study;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.repositories.SampleRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.TaxonomyRepository;
 import uk.ac.ebi.ena.sra.xml.AnalysisType;
 import uk.ac.ebi.ena.sra.xml.AssemblyType;
 import uk.ac.ebi.ena.sra.xml.LinkType;
+import uk.ac.ebi.ena.sra.xml.SampleType;
 import uk.ac.ebi.ena.sra.xml.StudyType;
 import uk.ac.ebi.ena.sra.xml.XRefType;
 
@@ -46,33 +48,47 @@ public class SraObjectsImporterThroughAPI extends ObjectsImporter {
 
     public SraObjectsImporterThroughAPI(
             SraXmlRetrieverThroughApi sraXmlRetrieverThroughApi,
+
             SraXmlParser<StudyType> sraStudyXmlParser,
+            SraXmlParser<AnalysisType> sraAnalysisXmlParser,
+            SraXmlParser<AssemblyType> sraAssemblyXmlParser,
+            SraXmlParser<SampleType> sraSampleXmlParser,
+
             Converter<StudyType, Study> studyConverter,
+            Converter<AnalysisType, Analysis> analysisConverter,
+            Converter<AssemblyType, ReferenceSequence> referenceSequenceConverter,
+            Converter<SampleType, Sample> sampleConverter,
+
             PublicationExtractorFromStudy publicationExtractorFromStudy,
             WebResourceExtractorFromStudy webResourceExtractorFromStudy,
-            SraXmlParser<AnalysisType> sraAnalysisXmlParser,
-            Converter<AnalysisType, Analysis> analysisConverter,
             FileExtractorFromAnalysis fileExtractorFromAnalysis,
-            SraXmlParser<AssemblyType> sraAssemblyXmlParser,
-            Converter<AssemblyType, ReferenceSequence> referenceSequenceConverter,
-            AnalysisRepository analysisRepository,
+
             StudyRepository studyRepository,
+            AnalysisRepository analysisRepository,
             ReferenceSequenceRepository referenceSequenceRepository,
+            SampleRepository sampleRepository,
             TaxonomyRepository taxonomyRepository) {
         super(
                 sraXmlRetrieverThroughApi,
+
                 sraStudyXmlParser,
                 sraAnalysisXmlParser,
                 sraAssemblyXmlParser,
+                sraSampleXmlParser,
+
                 studyConverter,
                 analysisConverter,
                 referenceSequenceConverter,
+                sampleConverter,
+
                 publicationExtractorFromStudy,
                 webResourceExtractorFromStudy,
                 fileExtractorFromAnalysis,
-                analysisRepository,
+
                 studyRepository,
+                analysisRepository,
                 referenceSequenceRepository,
+                sampleRepository,
                 taxonomyRepository
         );
     }
@@ -91,11 +107,6 @@ public class SraObjectsImporterThroughAPI extends ObjectsImporter {
     @Override
     protected Analysis extractStudyFromAnalysis(AnalysisType analysisType, Analysis analysis) {
         return analysis;
-    }
-
-    @Override
-    public Sample importSample(String accession) {
-        return null;
     }
 
     private Set<String> getAnalysisAccessions(StudyType studyType) {

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/configuration/MetadataImporterMainApplicationConfiguration.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/configuration/MetadataImporterMainApplicationConfiguration.java
@@ -26,6 +26,7 @@ import uk.ac.ebi.ampt2d.metadata.importer.api.SraObjectsImporterThroughAPI;
 import uk.ac.ebi.ampt2d.metadata.importer.api.SraXmlRetrieverThroughApi;
 import uk.ac.ebi.ampt2d.metadata.importer.converter.AnalysisConverter;
 import uk.ac.ebi.ampt2d.metadata.importer.converter.ReferenceSequenceConverter;
+import uk.ac.ebi.ampt2d.metadata.importer.converter.SampleConverter;
 import uk.ac.ebi.ampt2d.metadata.importer.converter.StudyConverter;
 import uk.ac.ebi.ampt2d.metadata.importer.database.SraObjectsImporterThroughDatabase;
 import uk.ac.ebi.ampt2d.metadata.importer.database.SraXmlRetrieverThroughDatabase;
@@ -34,10 +35,12 @@ import uk.ac.ebi.ampt2d.metadata.importer.extractor.PublicationExtractorFromStud
 import uk.ac.ebi.ampt2d.metadata.importer.extractor.WebResourceExtractorFromStudy;
 import uk.ac.ebi.ampt2d.metadata.importer.xml.SraAnalysisXmlParser;
 import uk.ac.ebi.ampt2d.metadata.importer.xml.SraAssemblyXmlParser;
+import uk.ac.ebi.ampt2d.metadata.importer.xml.SraSampleXmlParser;
 import uk.ac.ebi.ampt2d.metadata.importer.xml.SraStudyXmlParser;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.FileRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.PublicationRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.repositories.SampleRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.TaxonomyRepository;
@@ -55,21 +58,29 @@ public class MetadataImporterMainApplicationConfiguration {
                                                        TaxonomyRepository taxonomyRepository,
                                                        ReferenceSequenceRepository referenceSequenceRepository,
                                                        AnalysisRepository analysisRepository,
-                                                       StudyRepository studyRepository) {
+                                                       StudyRepository studyRepository,
+                                                       SampleRepository sampleRepository) {
         return new SraObjectsImporterThroughAPI(
                 sraXmlRetrieverThroughApi,
+
                 sraStudyXmlParser(),
+                sraAnalysisXmlParser(),
+                sraAssemblyXmlParser(),
+                sraSampleXmlParser(),
+
                 studyConverter(),
+                analysisConverter(),
+                referenceSequenceConverter(),
+                sampleConverter(),
+
                 publicationExtractorFromStudy(publicationRepository),
                 webResourceExtractorFromStudy(webResourceRepository),
-                sraAnalysisXmlParser(),
-                analysisConverter(),
                 fileExtractorFromAnalysis(fileRepository),
-                sraAssemblyXmlParser(),
-                referenceSequenceConverter(),
-                analysisRepository,
+
                 studyRepository,
+                analysisRepository,
                 referenceSequenceRepository,
+                sampleRepository,
                 taxonomyRepository
         );
     }
@@ -84,32 +95,34 @@ public class MetadataImporterMainApplicationConfiguration {
                                                 TaxonomyRepository taxonomyRepository,
                                                 ReferenceSequenceRepository referenceSequenceRepository,
                                                 AnalysisRepository analysisRepository,
-                                                StudyRepository studyRepository) {
+                                                StudyRepository studyRepository,
+                                                SampleRepository sampleRepository) {
         return new SraObjectsImporterThroughDatabase(
                 sraXmlRetrieverThroughDatabase,
+
                 sraStudyXmlParser(),
+                sraAnalysisXmlParser(),
+                sraAssemblyXmlParser(),
+                sraSampleXmlParser(),
+
                 studyConverter(),
+                analysisConverter(),
+                referenceSequenceConverter(),
+                sampleConverter(),
+
                 publicationExtractorFromStudy(publicationRepository),
                 webResourceExtractorFromStudy(webResourceRepository),
-                sraAnalysisXmlParser(),
-                analysisConverter(),
                 fileExtractorFromAnalysis(fileRepository),
-                sraAssemblyXmlParser(),
-                referenceSequenceConverter(),
-                analysisRepository,
+
                 studyRepository,
+                analysisRepository,
                 referenceSequenceRepository,
+                sampleRepository,
                 taxonomyRepository
         );
     }
 
-    private StudyConverter studyConverter() {
-        return new StudyConverter();
-    }
-
-    private AnalysisConverter analysisConverter() {
-        return new AnalysisConverter();
-    }
+    // Parser factories
 
     private SraStudyXmlParser sraStudyXmlParser() {
         return new SraStudyXmlParser();
@@ -119,13 +132,33 @@ public class MetadataImporterMainApplicationConfiguration {
         return new SraAnalysisXmlParser();
     }
 
-    private FileExtractorFromAnalysis fileExtractorFromAnalysis(FileRepository fileRepository) {
-        return new FileExtractorFromAnalysis(fileRepository);
+    private SraSampleXmlParser sraSampleXmlParser() {
+        return new SraSampleXmlParser();
     }
 
     private SraAssemblyXmlParser sraAssemblyXmlParser() {
         return new SraAssemblyXmlParser();
     }
+
+    // Converter factories
+
+    private StudyConverter studyConverter() {
+        return new StudyConverter();
+    }
+
+    private AnalysisConverter analysisConverter() {
+        return new AnalysisConverter();
+    }
+
+    private SampleConverter sampleConverter() {
+        return new SampleConverter();
+    }
+
+    private ReferenceSequenceConverter referenceSequenceConverter() {
+        return new ReferenceSequenceConverter();
+    }
+
+    // Extractor factories
 
     private PublicationExtractorFromStudy publicationExtractorFromStudy(PublicationRepository publicationRepository) {
         return new PublicationExtractorFromStudy(publicationRepository);
@@ -135,7 +168,8 @@ public class MetadataImporterMainApplicationConfiguration {
         return new WebResourceExtractorFromStudy(webResourceRepository);
     }
 
-    private ReferenceSequenceConverter referenceSequenceConverter() {
-        return new ReferenceSequenceConverter();
+    private FileExtractorFromAnalysis fileExtractorFromAnalysis(FileRepository fileRepository) {
+        return new FileExtractorFromAnalysis(fileRepository);
     }
+
 }

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/converter/SampleConverter.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/converter/SampleConverter.java
@@ -15,14 +15,21 @@
  * limitations under the License.
  *
  */
+package uk.ac.ebi.ampt2d.metadata.importer.converter;
 
-package uk.ac.ebi.ampt2d.metadata.importer.database;
+import org.springframework.core.convert.converter.Converter;
+import uk.ac.ebi.ampt2d.metadata.persistence.entities.AccessionVersionId;
+import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
+import uk.ac.ebi.ena.sra.xml.SampleType;
 
-public interface EnaObjectQuery {
+public class SampleConverter implements Converter<SampleType, Sample> {
 
-    String STUDY_QUERY = "SELECT STUDY_XML FROM ERA.STUDY WHERE STUDY_ID = :accession";
+    @Override
+    public Sample convert(SampleType sampleType) {
+        return new Sample(
+                new AccessionVersionId(sampleType.getAccession(), 1),
+                sampleType.getAlias()
+        );
+    }
 
-    String ANALYSIS_QUERY = "SELECT ANALYSIS_XML FROM ERA.ANALYSIS WHERE ANALYSIS_ID = :accession";
-
-    String SAMPLE_QUERY = "SELECT SAMPLE_XML FROM ERA.SAMPLE WHERE SAMPLE_ID = :accession";
 }

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/database/SraObjectsImporterThroughDatabase.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/database/SraObjectsImporterThroughDatabase.java
@@ -31,11 +31,13 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Study;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Taxonomy;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.repositories.SampleRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.TaxonomyRepository;
 import uk.ac.ebi.ena.sra.xml.AnalysisType;
 import uk.ac.ebi.ena.sra.xml.AssemblyType;
 import uk.ac.ebi.ena.sra.xml.ReferenceAssemblyType;
+import uk.ac.ebi.ena.sra.xml.SampleType;
 import uk.ac.ebi.ena.sra.xml.StudyType;
 
 import java.util.ArrayList;
@@ -87,33 +89,47 @@ public class SraObjectsImporterThroughDatabase extends ObjectsImporter {
 
     public SraObjectsImporterThroughDatabase(
             SraXmlRetrieverThroughDatabase sraXmlRetrieverThroughDatabase,
+
             SraXmlParser<StudyType> sraStudyXmlParser,
+            SraXmlParser<AnalysisType> sraAnalysisXmlParser,
+            SraXmlParser<AssemblyType> sraAssemblyXmlParser,
+            SraXmlParser<SampleType> sraSampleXmlParser,
+
             Converter<StudyType, Study> studyConverter,
+            Converter<AnalysisType, Analysis> analysisConverter,
+            Converter<AssemblyType, ReferenceSequence> referenceSequenceConverter,
+            Converter<SampleType, Sample> sampleConverter,
+
             PublicationExtractorFromStudy publicationExtractorFromStudy,
             WebResourceExtractorFromStudy webResourceExtractorFromStudy,
-            SraXmlParser<AnalysisType> sraAnalysisXmlParser,
-            Converter<AnalysisType, Analysis> analysisConverter,
             FileExtractorFromAnalysis fileExtractorFromAnalysis,
-            SraXmlParser<AssemblyType> sraAssemblyXmlParser,
-            Converter<AssemblyType, ReferenceSequence> referenceSequenceConverter,
-            AnalysisRepository analysisRepository,
+
             StudyRepository studyRepository,
+            AnalysisRepository analysisRepository,
             ReferenceSequenceRepository referenceSequenceRepository,
+            SampleRepository sampleRepository,
             TaxonomyRepository taxonomyRepository) {
         super(
                 sraXmlRetrieverThroughDatabase,
+
                 sraStudyXmlParser,
                 sraAnalysisXmlParser,
                 sraAssemblyXmlParser,
+                sraSampleXmlParser,
+
                 studyConverter,
                 analysisConverter,
                 referenceSequenceConverter,
+                sampleConverter,
+
                 publicationExtractorFromStudy,
                 webResourceExtractorFromStudy,
                 fileExtractorFromAnalysis,
-                analysisRepository,
+
                 studyRepository,
+                analysisRepository,
                 referenceSequenceRepository,
+                sampleRepository,
                 taxonomyRepository
         );
     }
@@ -158,7 +174,10 @@ public class SraObjectsImporterThroughDatabase extends ObjectsImporter {
 
     @Override
     public Sample importSample(String accession) {
-        return super.importSample(accession);
+        setEnaObjectQuery(EnaObjectQuery.SAMPLE_QUERY);
+        Sample sample = super.importSample(accession);
+        setEnaObjectQuery(EnaObjectQuery.ANALYSIS_QUERY);
+        return sample;
     }
 
     @Override

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/xml/SraSampleXmlParser.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/xml/SraSampleXmlParser.java
@@ -1,0 +1,44 @@
+/*
+ *
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package uk.ac.ebi.ampt2d.metadata.importer.xml;
+
+import org.apache.xmlbeans.XmlException;
+import uk.ac.ebi.ena.sra.xml.SAMPLEDocument;
+import uk.ac.ebi.ena.sra.xml.SampleType;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class SraSampleXmlParser extends SraXmlParser<SampleType> {
+
+    private static final Logger LOGGER = Logger.getLogger(SraSampleXmlParser.class.getName());
+
+    @Override
+    public SampleType parseXml(String xmlString, String accession) throws XmlException {
+        xmlString = removeRootTagsFromXmlString(xmlString); // For API calls
+        xmlString = removeSetTagsFromXmlString(xmlString); // For database queries
+        try {
+            return SAMPLEDocument.Factory.parse(xmlString).getSAMPLE();
+        } catch (XmlException e) {
+            LOGGER.log(Level.SEVERE, "An error occurred while parsing XML for accession " + accession);
+            throw e;
+        }
+    }
+
+}

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/MetadataImporterMainApplicationAPITest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/MetadataImporterMainApplicationAPITest.java
@@ -27,6 +27,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.repositories.SampleRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 
 import static org.junit.Assert.assertEquals;
@@ -45,6 +46,9 @@ public class MetadataImporterMainApplicationAPITest {
     @Autowired
     private AnalysisRepository analysisRepository;
 
+    @Autowired
+    private SampleRepository sampleRepository;
+
     @Before
     public void setUp() {
         analysisRepository.deleteAll();
@@ -57,6 +61,7 @@ public class MetadataImporterMainApplicationAPITest {
                 new String[]{"--accessions.file.path=study/StudyAccessions.txt"}));
         assertEquals(2, studyRepository.count());
         assertEquals(8, analysisRepository.count());
+        assertEquals(4, sampleRepository.count());
     }
 
     @Test(expected = RuntimeException.class)

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/MetadataImporterMainApplicationDBTest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/MetadataImporterMainApplicationDBTest.java
@@ -66,7 +66,7 @@ public class MetadataImporterMainApplicationDBTest {
         assertEquals(6, sampleRepository.count());
         sraObjectsImporterThroughDatabase.getAccessionsToStudy().clear();
 
-        // Import analysis having shared study that is already imported before
+        // Import additional analyses into already imported study
         metadataImporterMainApplication.run(new DefaultApplicationArguments(
                 new String[]{"--accessions.file.path=analysis/EgaAnalysisAccessionsSharedStudyPreviousImport.txt"}));
         assertEquals(2, studyRepository.count());

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/MetadataImporterMainApplicationDBTest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/MetadataImporterMainApplicationDBTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.ampt2d.metadata.importer.database.OracleDbCategory;
 import uk.ac.ebi.ampt2d.metadata.importer.database.SraObjectsImporterThroughDatabase;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.repositories.SampleRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 
 import static org.junit.Assert.assertEquals;
@@ -52,6 +53,9 @@ public class MetadataImporterMainApplicationDBTest {
     @Autowired
     private AnalysisRepository analysisRepository;
 
+    @Autowired
+    private SampleRepository sampleRepository;
+
     @Test
     @Category(OracleDbCategory.class)
     public void run() throws Exception {
@@ -59,7 +63,7 @@ public class MetadataImporterMainApplicationDBTest {
                 new String[]{"--accessions.file.path=analysis/EgaAnalysisAccessions.txt"}));
         assertEquals(2, studyRepository.count());
         assertEquals(6, analysisRepository.count());
-
+        assertEquals(6, sampleRepository.count());
         sraObjectsImporterThroughDatabase.getAccessionsToStudy().clear();
 
         // Import analysis having shared study that is already imported before
@@ -67,6 +71,7 @@ public class MetadataImporterMainApplicationDBTest {
                 new String[]{"--accessions.file.path=analysis/EgaAnalysisAccessionsSharedStudyPreviousImport.txt"}));
         assertEquals(2, studyRepository.count());
         assertEquals(11, analysisRepository.count());
+        assertEquals(11, sampleRepository.count());
     }
 
 }

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPITest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPITest.java
@@ -18,7 +18,6 @@
 
 package uk.ac.ebi.ampt2d.metadata.importer.api;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPITest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPITest.java
@@ -18,6 +18,7 @@
 
 package uk.ac.ebi.ampt2d.metadata.importer.api;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,6 +28,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.ampt2d.metadata.importer.MetadataImporterMainApplication;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Analysis;
+import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Study;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepository;
@@ -40,7 +42,6 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.ReferenceSequence;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Taxonomy;
 
 import java.util.Arrays;
-
 
 @RunWith(SpringRunner.class)
 @TestPropertySource(value = "classpath:application.properties", properties = {"import.source=API"})
@@ -114,9 +115,17 @@ public class SraObjectsImporterThroughAPITest {
         assertEquals("EquCab2.0", referenceSequence.getName());
         assertEquals(ReferenceSequence.Type.ASSEMBLY, referenceSequence.getType());
         Taxonomy taxonomy = referenceSequence.getTaxonomy();
-        assertEquals(9796, taxonomy.getTaxonomyId().longValue());
+        assertEquals(9796, taxonomy.getTaxonomyId());
         assertEquals("Equus caballus", taxonomy.getName());
         assertEquals(1, referenceSequenceRepository.count());
+    }
+
+    @Test
+    public void importSampleObject() throws Exception {
+        Sample sample = sraObjectImporter.importSample("ERS000156");
+        assertNotNull(sample);
+        assertEquals("ERS000156", sample.getAccessionVersionId().getAccession());
+        assertEquals("E-TABM-722:mmu5", sample.getName());
     }
 
 }

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPITest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/api/SraObjectsImporterThroughAPITest.java
@@ -32,6 +32,7 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Study;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.repositories.SampleRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 
 import java.time.LocalDate;
@@ -60,11 +61,15 @@ public class SraObjectsImporterThroughAPITest {
     @Autowired
     private ReferenceSequenceRepository referenceSequenceRepository;
 
+    @Autowired
+    private SampleRepository sampleRepository;
+
     @Before
     public void setUp() {
         analysisRepository.deleteAll();
         studyRepository.deleteAll();
         referenceSequenceRepository.deleteAll();
+        sampleRepository.deleteAll();
     }
 
     @Test
@@ -94,6 +99,7 @@ public class SraObjectsImporterThroughAPITest {
         assertEquals(3, studyRepository.count());
         assertEquals(2, analysisRepository.count());
         assertEquals(1, referenceSequenceRepository.count());
+        assertEquals(25, sampleRepository.count());
     }
 
     @Test

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/converter/SampleConverterTest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/converter/SampleConverterTest.java
@@ -61,6 +61,11 @@ public class SampleConverterTest {
         sampleConverter = new SampleConverter();
     }
 
+    @Test
+    public void convertFromApiXml() throws Exception {
+        testSample("ERS000156", SAMPLE_DOCUMENT_API_XML, "E-TABM-722:mmu5");
+    }
+
     private void testSample(String sampleAccession, String sampleDocumentXmlPath,
                             String expectedSampleName) throws Exception {
         SampleType sampleType = getSampleType(sampleDocumentXmlPath, sampleAccession);
@@ -68,11 +73,6 @@ public class SampleConverterTest {
         assertNotNull(sample);
         assertEquals(sampleAccession, sample.getAccessionVersionId().getAccession());
         assertEquals(expectedSampleName, sample.getName());
-    }
-
-    @Test
-    public void convertFromApiXml() throws Exception {
-        testSample("ERS000156", SAMPLE_DOCUMENT_API_XML, "E-TABM-722:mmu5");
     }
 
     @Test

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/converter/SampleConverterTest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/converter/SampleConverterTest.java
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package uk.ac.ebi.ampt2d.metadata.importer.converter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.ac.ebi.ampt2d.metadata.importer.api.SraApiConfiguration;
+import uk.ac.ebi.ampt2d.metadata.importer.configuration.MetadataDatabaseConfiguration;
+import uk.ac.ebi.ampt2d.metadata.importer.configuration.MetadataImporterMainApplicationConfiguration;
+import uk.ac.ebi.ampt2d.metadata.importer.xml.SraSampleXmlParser;
+import uk.ac.ebi.ampt2d.metadata.importer.xml.SraXmlParser;
+import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
+import uk.ac.ebi.ena.sra.xml.SampleType;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {MetadataImporterMainApplicationConfiguration.class,
+        MetadataDatabaseConfiguration.class,
+        SraApiConfiguration.class})
+@EnableAutoConfiguration
+@TestPropertySource(locations = "classpath:application.properties", properties = {"import.source=API"})
+public class SampleConverterTest {
+
+    private static final String SAMPLE_DOCUMENT_API_XML = "sample/SampleDocumentAPI.xml";
+
+    private static final String SAMPLE_DOCUMENT_DATABASE_XML = "sample/SampleDocumentDB.xml";
+
+    private SraXmlParser<SampleType> xmlParser;
+
+    private SampleConverter sampleConverter;
+
+    @Before
+    public void setUp() {
+        xmlParser = new SraSampleXmlParser();
+        sampleConverter = new SampleConverter();
+    }
+
+    private void testSample(String sampleAccession, String sampleDocumentXmlPath,
+                            String expectedSampleName) throws Exception {
+        SampleType sampleType = getSampleType(sampleDocumentXmlPath, sampleAccession);
+        Sample sample = sampleConverter.convert(sampleType);
+        assertNotNull(sample);
+        assertEquals(sampleAccession, sample.getAccessionVersionId().getAccession());
+        assertEquals(expectedSampleName, sample.getName());
+    }
+
+    @Test
+    public void convertFromApiXml() throws Exception {
+        testSample("ERS000156", SAMPLE_DOCUMENT_API_XML, "E-TABM-722:mmu5");
+    }
+
+    @Test
+    public void convertFromDbXml() throws Exception {
+        testSample("ERS000002", SAMPLE_DOCUMENT_DATABASE_XML,
+                   "Solexa sequencing of Saccharomyces cerevisiae strain SK1 random 200 bp library");
+    }
+
+    private SampleType getSampleType(String xml, String accession) throws Exception {
+        String xmlString = new String(Files.readAllBytes(
+                Paths.get(getClass().getClassLoader().getResource(xml).toURI())));
+        return xmlParser.parseXml(xmlString, accession);
+    }
+
+}

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/database/SraObjectsImporterThroughDBTest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/database/SraObjectsImporterThroughDBTest.java
@@ -18,6 +18,7 @@
 
 package uk.ac.ebi.ampt2d.metadata.importer.database;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,12 +30,17 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.ac.ebi.ampt2d.metadata.importer.MetadataImporterMainApplication;
 import uk.ac.ebi.ampt2d.metadata.importer.ObjectsImporter;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Analysis;
+import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Study;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.AnalysisRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepository;
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -97,6 +103,15 @@ public class SraObjectsImporterThroughDBTest {
         assertEquals(1, studyRepository.count());
         assertEquals(1, analysisRepository.count());
         assertEquals(1, referenceSequenceRepository.count());
+    }
+
+    @Test
+    @Category(OracleDbCategory.class)
+    public void importSampleObject() throws Exception {
+        Sample sample = sraObjectImporter.importSample("ERS000002");
+        assertNotNull(sample);
+        assertEquals("ERS000002", sample.getAccessionVersionId().getAccession());
+        assertEquals("Solexa sequencing of Saccharomyces cerevisiae strain SK1 random 200 bp library", sample.getName());
     }
 
 }

--- a/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/database/SraObjectsImporterThroughDBTest.java
+++ b/metadata-load/src/test/java/uk/ac/ebi/ampt2d/metadata/importer/database/SraObjectsImporterThroughDBTest.java
@@ -18,7 +18,6 @@
 
 package uk.ac.ebi.ampt2d.metadata.importer.database;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,10 +36,6 @@ import uk.ac.ebi.ampt2d.metadata.persistence.repositories.ReferenceSequenceRepos
 import uk.ac.ebi.ampt2d.metadata.persistence.repositories.StudyRepository;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/metadata-load/src/test/resources/sample/SampleDocumentAPI.xml
+++ b/metadata-load/src/test/resources/sample/SampleDocumentAPI.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ROOT request="ERS000156&amp;display=xml">
+    <SAMPLE accession="ERS000156" alias="E-TABM-722:mmu5" broker_name="ArrayExpress" center_name="CRUK-CRI">
+        <IDENTIFIERS>
+            <PRIMARY_ID>ERS000156</PRIMARY_ID>
+            <EXTERNAL_ID namespace="BioSample">SAMEA907007</EXTERNAL_ID>
+            <SUBMITTER_ID namespace="CRUK-CRI">E-TABM-722:mmu5</SUBMITTER_ID>
+        </IDENTIFIERS>
+        <TITLE>Mus musculus</TITLE>
+        <SAMPLE_NAME>
+            <TAXON_ID>10090</TAXON_ID>
+            <COMMON_NAME>house mouse</COMMON_NAME>
+            <SCIENTIFIC_NAME>Mus musculus</SCIENTIFIC_NAME>
+        </SAMPLE_NAME>
+        <SAMPLE_LINKS>
+            <SAMPLE_LINK>
+                <XREF_LINK>
+                    <DB>ENA-STUDY</DB>
+                    <ID>ERP000054</ID>
+                </XREF_LINK>
+            </SAMPLE_LINK>
+            <SAMPLE_LINK>
+                <XREF_LINK>
+                    <DB>ENA-EXPERIMENT</DB>
+                    <ID>ERX000527</ID>
+                </XREF_LINK>
+            </SAMPLE_LINK>
+            <SAMPLE_LINK>
+                <XREF_LINK>
+                    <DB>ENA-RUN</DB>
+                    <ID>ERR005109</ID>
+                </XREF_LINK>
+            </SAMPLE_LINK>
+            <SAMPLE_LINK>
+                <XREF_LINK>
+                    <DB>ENA-SUBMISSION</DB>
+                    <ID>ERA000098</ID>
+                </XREF_LINK>
+            </SAMPLE_LINK>
+            <SAMPLE_LINK>
+                <XREF_LINK>
+                    <DB>ENA-FASTQ-FILES</DB>
+                    <ID><![CDATA[http://www.ebi.ac.uk/ena/data/warehouse/filereport?accession=ERS000156&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>
+                </XREF_LINK>
+            </SAMPLE_LINK>
+            <SAMPLE_LINK>
+                <XREF_LINK>
+                    <DB>ENA-SUBMITTED-FILES</DB>
+                    <ID><![CDATA[http://www.ebi.ac.uk/ena/data/warehouse/filereport?accession=ERS000156&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>
+                </XREF_LINK>
+            </SAMPLE_LINK>
+        </SAMPLE_LINKS>
+        <SAMPLE_ATTRIBUTES>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>OrganismPart</TAG>
+                <VALUE>liver</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>DevelopmentalStage</TAG>
+                <VALUE>adult</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>Experimental Factor: ORGANISMPART</TAG>
+                <VALUE>OrganismPart: liver</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>Organism</TAG>
+                <VALUE>Mus musculus</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>Individual</TAG>
+                <VALUE>mmu5</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>Sex</TAG>
+                <VALUE>male</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>Experimental Factor: ORGANISM</TAG>
+                <VALUE>Organism: Mus musculus</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>ENA-SPOT-COUNT</TAG>
+                <VALUE>16253687</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>ENA-BASE-COUNT</TAG>
+                <VALUE>731415915</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>ENA-FIRST-PUBLIC</TAG>
+                <VALUE>2010-04-09</VALUE>
+            </SAMPLE_ATTRIBUTE>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>ENA-LAST-UPDATE</TAG>
+                <VALUE>2018-03-08</VALUE>
+            </SAMPLE_ATTRIBUTE>
+        </SAMPLE_ATTRIBUTES>
+    </SAMPLE>
+</ROOT>

--- a/metadata-load/src/test/resources/sample/SampleDocumentDB.xml
+++ b/metadata-load/src/test/resources/sample/SampleDocumentDB.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SAMPLE_SET>
+    <SAMPLE accession="ERS000002" alias="Solexa sequencing of Saccharomyces cerevisiae strain SK1 random 200 bp library" center_name="SC">
+        <IDENTIFIERS>
+            <PRIMARY_ID>ERS000002</PRIMARY_ID>
+            <SUBMITTER_ID namespace="SC">Solexa sequencing of Saccharomyces cerevisiae strain SK1 random 200 bp library</SUBMITTER_ID>
+        </IDENTIFIERS>
+        <SAMPLE_NAME>
+            <TAXON_ID>580239</TAXON_ID>
+            <SCIENTIFIC_NAME>Saccharomyces cerevisiae SK1</SCIENTIFIC_NAME>
+        </SAMPLE_NAME>
+        <DESCRIPTION>Solexa sequencing of Saccharomyces cerevisiae strain SK1 random 200 bp library</DESCRIPTION>
+        <SAMPLE_ATTRIBUTES>
+            <SAMPLE_ATTRIBUTE>
+                <TAG>strain</TAG>
+                <VALUE>SK1</VALUE>
+            </SAMPLE_ATTRIBUTE>
+        </SAMPLE_ATTRIBUTES>
+    </SAMPLE>
+</SAMPLE_SET>

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/Sample.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/Sample.java
@@ -25,10 +25,10 @@ import org.hibernate.annotations.Formula;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-import javax.persistence.ManyToMany;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -40,13 +40,13 @@ import java.util.List;
 
 @Entity
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"accession", "version"}))
-@SequenceGenerator(initialValue=1, allocationSize=1 , name="SAMPLE_SEQ", sequenceName="sample_sequence")
+@SequenceGenerator(initialValue = 1, allocationSize = 1, name = "SAMPLE_SEQ", sequenceName = "sample_sequence")
 public class Sample extends Auditable<Long> {
 
     @ApiModelProperty(position = 1, value = "Sample auto generated id", readOnly = true)
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator="SAMPLE_SEQ")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SAMPLE_SEQ")
     private long id;
 
     @ApiModelProperty(position = 2)
@@ -69,7 +69,11 @@ public class Sample extends Auditable<Long> {
     @Size(min = 1)
     private List<Taxonomy> taxonomies;
 
-    Sample() {
+    public Sample() {}
+
+    public Sample(AccessionVersionId accessionVersionId, String name) {
+        this.accessionVersionId = accessionVersionId;
+        this.name = name;
     }
 
     public Sample(AccessionVersionId accessionVersionId, String name, List<Taxonomy> taxonomies) {
@@ -87,8 +91,16 @@ public class Sample extends Auditable<Long> {
         return accessionVersionId;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public List<Taxonomy> getTaxonomies() {
         return taxonomies;
+    }
+
+    public void setTaxonomies(List<Taxonomy> taxonomies) {
+        this.taxonomies = taxonomies;
     }
 
     /**

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/Study.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/Study.java
@@ -19,7 +19,6 @@ package uk.ac.ebi.ampt2d.metadata.persistence.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
-import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.JoinFormula;
 import org.hibernate.validator.constraints.NotBlank;
 

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/Taxonomy.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/Taxonomy.java
@@ -34,13 +34,13 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Entity
-@SequenceGenerator(initialValue=1, allocationSize=1 , name="TAXONOMY_SEQ", sequenceName="taxonomy_sequence")
+@SequenceGenerator(allocationSize = 1, name = "TAXONOMY_SEQ", sequenceName = "taxonomy_sequence")
 public class Taxonomy extends Auditable<Long> {
 
     @ApiModelProperty(position = 1, value = "Taxonomy auto generated id", readOnly = true)
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator="TAXONOMY_SEQ")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "TAXONOMY_SEQ")
     private long id;
 
     @ApiModelProperty(position = 2, example = "1")
@@ -72,9 +72,13 @@ public class Taxonomy extends Auditable<Long> {
         return id;
     }
 
-    public Long getTaxonomyId() { return taxonomyId; }
+    public long getTaxonomyId() {
+        return taxonomyId;
+    }
 
-    public String getName() { return name; }
+    public String getName() {
+        return name;
+    }
 
     /**
      * Release date control: taxonomies are always public.

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleCustomRepository.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleCustomRepository.java
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package uk.ac.ebi.ampt2d.metadata.persistence.repositories;
+
+import org.springframework.data.querydsl.QueryDslPredicateExecutor;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import uk.ac.ebi.ampt2d.metadata.persistence.entities.QSample;
+import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
+
+@NoRepositoryBean
+public interface SampleCustomRepository extends PagingAndSortingRepository<Sample, Long>,
+        QueryDslPredicateExecutor<Sample> {
+
+    QSample qSample = QSample.sample;
+
+    default Sample findOrSave(Sample sample) {
+        Sample existingSample = findOne(
+                qSample.accessionVersionId.accession.eq(sample.getAccessionVersionId().getAccession()).and(
+                qSample.accessionVersionId.version.eq(sample.getAccessionVersionId().getVersion()))
+        );
+        if (existingSample != null) {
+            return existingSample;
+        }
+        return save(sample);
+    }
+}

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepository.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepository.java
@@ -31,8 +31,7 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 import java.util.List;
 
 @RepositoryRestResource
-public interface SampleRepository extends PagingAndSortingRepository<Sample, Long>, QueryDslPredicateExecutor<Sample>,
-        QuerydslBinderCustomizer<QSample> {
+public interface SampleRepository extends SampleCustomRepository, QuerydslBinderCustomizer<QSample> {
 
     default void customize(QuerydslBindings bindings, QSample qSample) {
         bindings.bind(qSample.taxonomies.any().name)
@@ -43,4 +42,5 @@ public interface SampleRepository extends PagingAndSortingRepository<Sample, Lon
     @RestResource(path = "/accession")
     List<Sample> findFirstByAccessionVersionId_AccessionOrderByAccessionVersionId_VersionDesc
             (@Param("accession") String accession);
+
 }

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepository.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepository.java
@@ -18,10 +18,8 @@
 package uk.ac.ebi.ampt2d.metadata.persistence.repositories;
 
 import io.swagger.annotations.ApiOperation;
-import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
-import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepository.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepository.java
@@ -29,7 +29,7 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 import java.util.List;
 
 @RepositoryRestResource
-public interface SampleRepository extends SampleCustomRepository, QuerydslBinderCustomizer<QSample> {
+public interface SampleRepository extends SampleRepositoryCustom, QuerydslBinderCustomizer<QSample> {
 
     default void customize(QuerydslBindings bindings, QSample qSample) {
         bindings.bind(qSample.taxonomies.any().name)

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepositoryCustom.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepositoryCustom.java
@@ -25,7 +25,7 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.QSample;
 import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 
 @NoRepositoryBean
-public interface SampleCustomRepository extends PagingAndSortingRepository<Sample, Long>,
+public interface SampleRepositoryCustom extends PagingAndSortingRepository<Sample, Long>,
         QueryDslPredicateExecutor<Sample> {
 
     QSample qSample = QSample.sample;

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepositoryCustom.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/SampleRepositoryCustom.java
@@ -27,7 +27,6 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Sample;
 @NoRepositoryBean
 public interface SampleRepositoryCustom extends PagingAndSortingRepository<Sample, Long>,
         QueryDslPredicateExecutor<Sample> {
-
     QSample qSample = QSample.sample;
 
     default Sample findOrSave(Sample sample) {

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/TaxonomyRepository.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/TaxonomyRepository.java
@@ -26,4 +26,5 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.Taxonomy;
 public interface TaxonomyRepository extends TaxonomyRepositoryCustom, PagingAndSortingRepository<Taxonomy, Long> {
 
     Taxonomy findByTaxonomyId(@Param("taxonomyId") long taxonomyId);
+
 }

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/WebResourceRepository.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/repositories/WebResourceRepository.java
@@ -25,4 +25,5 @@ import uk.ac.ebi.ampt2d.metadata.persistence.entities.WebResource;
 public interface WebResourceRepository extends PagingAndSortingRepository<WebResource, Long> {
 
     WebResource findByResourceUrl(String url);
+
 }

--- a/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/AnalysisSteps.java
+++ b/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/AnalysisSteps.java
@@ -20,7 +20,6 @@ package uk.ac.ebi.ampt2d.metadata.cucumber;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;

--- a/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/SampleSteps.java
+++ b/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/SampleSteps.java
@@ -20,7 +20,6 @@ package uk.ac.ebi.ampt2d.metadata.cucumber;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;

--- a/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/StudySteps.java
+++ b/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/StudySteps.java
@@ -19,7 +19,6 @@ package uk.ac.ebi.ampt2d.metadata.cucumber;
 
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;


### PR DESCRIPTION
### [Diff link](https://github.com/tskir/metadata-ws/compare/t2d-307-study-taxonomy...t2d-291-store-sample?expand=1)

Based on the [original implementation](https://github.com/EBIvariation/metadata-ws/pull/49) by @selvaebi. Changes that I introduced:

* Rebased on top of changes in #47, #50, #53, and #54.
* Updated the modules to reflect the new design guidelines:
  + General/API/Database importer and the configuration
  + `SampleConverter`
  + `Sample`'s constuctors
  + Sample import (taxonomy extraction, persistence)
  + Imports in all modules
* Implemented new modules:
  + `MetadataSampleFinderOrPersister`
  + `TaxonomyExtractorFromSample`
* Updated/moved the tests:
  + SraObjectsImporterThroughAPITest
  + SraObjectsImporterThroughDBTest
  + PersistenceApplicationRunnerApiTest
  + PersistenceApplicationRunnerDbTest
  + SampleConverterTest
  + Renamed test files to follow the new convention
* Fixed the race condition in database import

**Ready for the first iteration of review.** Here's a [diff link](https://github.com/tskir/metadata-ws/compare/t2d-307-study-taxonomy...t2d-291-store-sample?expand=1) as usual, which reflects only the changes related to this pull request.