### PR TITLE
T2D-370 — Make Travis logs less noisy and increase reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
   - openjdk8
 
 install:
-  - >
+  - |
     for i in 1 2 3 4 5; do
       echo "Trying to set up Maven, attempt number $i"
       rm -rf ~/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,19 @@ sudo: false
 
 language: java
 
+git:
+  quiet: true
+
 jdk:
   - openjdk8
 
 install:
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -PTravis
+  - >
+    for i in 1 2 3 4 5; do
+      echo "Trying to set up Maven, attempt number $i"
+      rm -rf ~/.m2
+      mvn clean install -PTravis -DskipTests=true -Dmaven.javadoc.skip=true -B -V -q && break || sleep 5;
+    done
 
 script:
-  - mvn test -PTravis
+  - travis_wait mvn test -PTravis -q

--- a/metadata-load/pom.xml
+++ b/metadata-load/pom.xml
@@ -35,14 +35,6 @@
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
         </dependency>

--- a/metadata-load/src/test/resources/logback-test.xml
+++ b/metadata-load/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml" />
-    <logger name="root" level="INFO"/>
+    <logger name="root" level="WARN"/>
 </configuration>

--- a/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/MetadataWSIntegrationTest.java
+++ b/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/MetadataWSIntegrationTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
         },
         strict = true,
         plugin = {
-                "pretty",
+                "progress",
                 "html:target/cucumber"
         },
         tags = { "not @ignore" }

--- a/metadata-ws/src/test/resources/logback-test.xml
+++ b/metadata-ws/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml" />
-    <logger name="root" level="INFO"/>
+    <logger name="root" level="WARN"/>
 </configuration>


### PR DESCRIPTION
* Fix dirty Maven environment on Travis instances by removing `~/.m2` directory before doing anything
* Make Maven setup more reliable by making multiple attempts — this fixes the intermittent download errors from Maven servers
* Make testing logs (much) less noisy
  + Set default logging level to WARN
  + Make cloning, Maven install & testing phases more quiet
  + Decrease Cucumber verbosity