### PR TITLE
T2D-356 — Fix sporadic reference sequence import error

### DIFF
--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/api/ReferenceSequenceXmlRetrieverThroughEntrezApi.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/api/ReferenceSequenceXmlRetrieverThroughEntrezApi.java
@@ -61,17 +61,15 @@ public class ReferenceSequenceXmlRetrieverThroughEntrezApi {
     }
 
     private String fetchEntrezId(String accession, String entrezDatabase) {
-        ResponseEntity<String> response = restTemplate.exchange(
+        return restTemplate.exchange(
                 entrezApiIdRetrievalUrl, HttpMethod.GET, null, String.class,
-                entrezDatabase, accession, entrezApiKey);
-        return response.getBody();
+                entrezDatabase, accession, entrezApiKey).getBody();
     }
 
     private String fetchEntrezData(String id, String entrezDatabase) {
-        ResponseEntity<String> response = restTemplate.exchange(
+        return restTemplate.exchange(
                 entrezApiAssemblyRetrievalUrl, HttpMethod.GET, null, String.class,
-                entrezDatabase, id, entrezApiKey);
-        return response.getBody();
+                entrezDatabase, id, entrezApiKey).getBody();
     }
 
     @Retryable(maxAttemptsExpression="#{${entrez.api.attempts}}",
@@ -91,7 +89,7 @@ public class ReferenceSequenceXmlRetrieverThroughEntrezApi {
                 dataXml.indexOf(DATA_ID_END_TAG));
         if (idFromData.isEmpty()) {
             // This check is here to ensure that the result which Entrez returns is actually meaningful. Sometimes,
-            // rarely and sporadically, Entrez does return either an empty XML, or an XML complaining about about
+            // rarely and sporadically, Entrez does return either an empty XML, or an XML complaining about
             // backend error, without any actual information. The exception below is thrown so that the @Retryable
             // annotation can kick in and resolve the issue.
             throw new AssertionError("Entrez error: received a malformed XML for accession " + accession);

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/api/ReferenceSequenceXmlRetrieverThroughEntrezApi.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/api/ReferenceSequenceXmlRetrieverThroughEntrezApi.java
@@ -30,9 +30,11 @@ public class ReferenceSequenceXmlRetrieverThroughEntrezApi {
 
     private static final String ID_END_TAG = "</Id>";
 
-    private static final String ENTREZ_API_KEY_QUERY = "&api_key={entrezApiKey}";
+    private static final String ASSEMBLY_ID_START_TAG = "<RsUid>";
 
-    private static final int ID_START_TAG_LENGTH = 4;
+    private static final String ASSEMBLY_ID_END_TAG = "</RsUid>";
+
+    private static final String ENTREZ_API_KEY_QUERY = "&api_key={entrezApiKey}";
 
     /*
      *  URL to obtain an internal Entrez ID from, given an NCBI database and a sequence accession
@@ -78,17 +80,23 @@ public class ReferenceSequenceXmlRetrieverThroughEntrezApi {
         // First we query the appropriate Entrez database with an accession to find out the corresponding internal ID.
         // For example, if we have AJPT01332946.1 and query the nuccore database, it'll return an ID of 428325741.
         String idXml = fetchEntrezId(accession, entrezDatabase);
-        String id = idXml.substring(idXml.indexOf(ID_START_TAG) + ID_START_TAG_LENGTH, idXml.indexOf(ID_END_TAG));
+        String id = idXml.substring(idXml.indexOf(ID_START_TAG) + ID_START_TAG.length(), idXml.indexOf(ID_END_TAG));
+
         // Now, having an internal ID, we query the corresponding Entrez database to get the necessary data.
         String dataXml = fetchEntrezData(id, entrezDatabase);
-        String idFromData = dataXml.substring(idXml.indexOf(ID_START_TAG) + ID_START_TAG_LENGTH, idXml.indexOf(ID_END_TAG));
-        if (! id.equals(idFromData)) {
-            // This check is here to ensure that the result which Entrez returns is actually meaningful and does contain
-            // the same ID which it was queried with. Sometimes, rarely and sporadically, Entrez does return either an
-            // empty XML, or an XML complaining about about backend error, without any actual information. The exception
-            // below is thrown so that the @Retryable annotation can kick in and resolve the issue.
-            throw new AssertionError("Entrez error: identifiers from ID XML and data XML do not match");
+        boolean isAssembly = entrezDatabase.equals("assembly");
+        String DATA_ID_START_TAG = isAssembly ? ASSEMBLY_ID_START_TAG : ID_START_TAG;
+        String DATA_ID_END_TAG = isAssembly ? ASSEMBLY_ID_END_TAG : ID_END_TAG;
+        String idFromData = dataXml.substring(dataXml.indexOf(DATA_ID_START_TAG) + DATA_ID_START_TAG.length(),
+                dataXml.indexOf(DATA_ID_END_TAG));
+        if (idFromData.isEmpty()) {
+            // This check is here to ensure that the result which Entrez returns is actually meaningful. Sometimes,
+            // rarely and sporadically, Entrez does return either an empty XML, or an XML complaining about about
+            // backend error, without any actual information. The exception below is thrown so that the @Retryable
+            // annotation can kick in and resolve the issue.
+            throw new AssertionError("Entrez error: received a malformed XML for accession " + accession);
         }
+
         return dataXml;
     }
 

--- a/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/xml/EntrezAssemblyXmlParser.java
+++ b/metadata-load/src/main/java/uk/ac/ebi/ampt2d/metadata/importer/xml/EntrezAssemblyXmlParser.java
@@ -57,13 +57,12 @@ public class EntrezAssemblyXmlParser {
 
             // Create new taxonomy
             long taxonomyId = Long.parseLong(domQueryUsingXPath.findInDom(xmlPath + taxIdXmlPath));
-            // TODO: NCBI provides species names for assemblies, but not for sequences from the `nuccore` database.
-            String taxonomyName = isAssembly ? domQueryUsingXPath.findInDom(xmlPath + "SpeciesName") : "no name";
             Taxonomy taxonomy = new Taxonomy(taxonomyId);
             referenceSequence.setTaxonomy(taxonomy);
             return referenceSequence;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "An error occurred while parsing XML for accession " + accession);
+            LOGGER.log(Level.SEVERE, xmlString);
             throw e;
         }
     }


### PR DESCRIPTION
The sporadic import error is fixed by checking the Entrez result _inside_ a `@Retryable` function, so in the rare cases when an error occurs, the whole Entrez query will be retried.