### PR TITLE
T2D-363 — Validate study accession on creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Metadata API for projects that follow the SRA model, such as those submitted to 
 
 Available documentation:
 * Using the metadata service
-  + [Querying](docs/querying.md)
+  + [Using the service](docs/using-the-service.md)
   + [Release date control](docs/release-date.md)
   + [Security](docs/security.md)
 * Notes on import

--- a/docs/using-the-service.md
+++ b/docs/using-the-service.md
@@ -1,4 +1,8 @@
-# Querying the metadata service
+# Using the metadata service
+
+## Study queries
+
+Please note that a comma symbol (`,`) is not permitted to be used in a study accession, because this symbol is used to separate study accessions when configuring access control.
 
 ## Analysis queries
 

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/AccessionVersionId.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/AccessionVersionId.java
@@ -37,7 +37,7 @@ public class AccessionVersionId implements Serializable {
     @ApiModelProperty(position = 1)
     @NotNull
     @Size(min = 1, max = 255)
-    @Pattern(regexp = "^[^.,]+$")
+    @Pattern(regexp = "^[^.,]*$")
     private String accession;
 
     @ApiModelProperty(example = "1")

--- a/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/AccessionVersionId.java
+++ b/metadata-ws/src/main/java/uk/ac/ebi/ampt2d/metadata/persistence/entities/AccessionVersionId.java
@@ -22,15 +22,22 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 
 @Embeddable
 public class AccessionVersionId implements Serializable {
 
+    /**
+     * @Pattern annotation ensures that the accession does not contain dot and comma symbols. Dots are commonly used
+     * to separate accession from version; commas are used in the security configuration to separate multiple
+     * accessions.
+     */
     @ApiModelProperty(position = 1)
     @NotNull
     @Size(min = 1, max = 255)
+    @Pattern(regexp = "^[^.,]+$")
     private String accession;
 
     @ApiModelProperty(example = "1")

--- a/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/StudySteps.java
+++ b/metadata-ws/src/test/java/uk/ac/ebi/ampt2d/metadata/cucumber/StudySteps.java
@@ -52,6 +52,16 @@ public class StudySteps {
         ));
     }
 
+    /**
+     * In contrast with the previous method, this one does *not* check that the creation was successful.
+     */
+    @When("I attempt to create a study with (.*) for accession$")
+    public void createTestStudyWithAccessionNoExpect(String accession) throws Exception {
+        CommonStates.setResultActions(postTestStudyNoExpect(
+                accession, 1, "test_human_study", false, LocalDate.now()
+        ));
+    }
+
     @When("^I request POST /studies with JSON-like payload:$")
     public void postTestStudy(String jsonLikeData) throws Exception {
         String[] values = jsonLikeData.split(",");
@@ -139,7 +149,7 @@ public class StudySteps {
         CommonStates.getResultActions().andExpect(jsonPath("$."+field).doesNotExist());
     }
 
-    private ResultActions postTestStudy(String accession, int version, String name, boolean deprecated, LocalDate releaseDate) throws Exception {
+    private ResultActions postTestStudyNoExpect(String accession, int version, String name, boolean deprecated, LocalDate releaseDate) throws Exception {
         String jsonContent = "{" +
                 "      \"accessionVersionId\": {" +
                 "       \"accession\": \"" + accession +  "\"," +
@@ -151,11 +161,13 @@ public class StudySteps {
                 "      \"deprecated\": \"" + deprecated + "\"," +
                 "      \"releaseDate\": \"" + releaseDate + "\"" +
                 "    }";
-
         return mockMvc.perform(post("/studies")
                 .with(CommonStates.getRequestPostProcessor())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(jsonContent))
-                .andExpect(status().isCreated());
+                .content(jsonContent));
+    }
+
+    private ResultActions postTestStudy(String accession, int version, String name, boolean deprecated, LocalDate releaseDate) throws Exception {
+        return postTestStudyNoExpect(accession, version, name, deprecated, releaseDate).andExpect(status().isCreated());
     }
 }

--- a/metadata-ws/src/test/resources/features/sample.feature
+++ b/metadata-ws/src/test/resources/features/sample.feature
@@ -334,5 +334,5 @@ Feature: sample object
 
     Examples:
       | accession | version | property                     | message                            |
-      |           | 1       | accessionVersionId.accession | size must be between 1 and 255     |
+      |           | 1       | accessionVersionId.accession | must match "^[^.,]+$"              |
       | EGAN0001  | 0       | accessionVersionId.version   | must be greater than or equal to 1 |

--- a/metadata-ws/src/test/resources/features/sample.feature
+++ b/metadata-ws/src/test/resources/features/sample.feature
@@ -334,5 +334,5 @@ Feature: sample object
 
     Examples:
       | accession | version | property                     | message                            |
-      |           | 1       | accessionVersionId.accession | must match "^[^.,]+$"              |
+      |           | 1       | accessionVersionId.accession | size must be between 1 and 255     |
       | EGAN0001  | 0       | accessionVersionId.version   | must be greater than or equal to 1 |

--- a/metadata-ws/src/test/resources/features/study.feature
+++ b/metadata-ws/src/test/resources/features/study.feature
@@ -1013,7 +1013,11 @@ Feature: study object
     Then the response code should be 400
 
 
-  Scenario: Trying to create a study with an invalid accession name (containing a comma symbol) must fail
+  Scenario Outline: Trying to create a study with an invalid accession name (containing a comma symbol) must fail
     Given I set authorization with testoperator having SERVICE_OPERATOR role
-    When I attempt to create a study with INVALID,ACCESSION for accession
+    When I attempt to create a study with <invalid_accession> for accession
     Then the response code should be 4xx
+    Examples:
+      | invalid_accession |
+      | CONTAINING,COMMA  |
+      | CONTAINING.DOT    |

--- a/metadata-ws/src/test/resources/features/study.feature
+++ b/metadata-ws/src/test/resources/features/study.feature
@@ -1011,3 +1011,22 @@ Feature: study object
 
     When I request PATCH STUDY with content {""}
     Then the response code should be 400
+
+
+    Given I set authorization with testoperator having SERVICE_OPERATOR role
+    # Create a taxonomy
+    When I request POST taxonomy with 9606 for ID
+    Then set the URL to TAXONOMY
+    # Create a reference sequence
+    When I request POST /reference-sequences with JSON-like payload:
+    """
+      "name": "GRCh37",
+      "patch": "p2",
+      "accession": "GCA_000001405.3",
+      "type": "GENOME_ASSEMBLY",
+      "taxonomy": "TAXONOMY"
+    """
+    Then set the URL to REFERENCE_SEQUENCE
+    # Create a study
+    When I create a study with INVALID,ACCESSION for accession
+    Then the response code should be 400

--- a/metadata-ws/src/test/resources/features/study.feature
+++ b/metadata-ws/src/test/resources/features/study.feature
@@ -1013,6 +1013,7 @@ Feature: study object
     Then the response code should be 400
 
 
+  Scenario: Trying to create a study with an invalid accession name (containing a comma symbol) must fail
     Given I set authorization with testoperator having SERVICE_OPERATOR role
     # Create a taxonomy
     When I request POST taxonomy with 9606 for ID

--- a/metadata-ws/src/test/resources/features/study.feature
+++ b/metadata-ws/src/test/resources/features/study.feature
@@ -1015,19 +1015,5 @@ Feature: study object
 
   Scenario: Trying to create a study with an invalid accession name (containing a comma symbol) must fail
     Given I set authorization with testoperator having SERVICE_OPERATOR role
-    # Create a taxonomy
-    When I request POST taxonomy with 9606 for ID
-    Then set the URL to TAXONOMY
-    # Create a reference sequence
-    When I request POST /reference-sequences with JSON-like payload:
-    """
-      "name": "GRCh37",
-      "patch": "p2",
-      "accession": "GCA_000001405.3",
-      "type": "GENOME_ASSEMBLY",
-      "taxonomy": "TAXONOMY"
-    """
-    Then set the URL to REFERENCE_SEQUENCE
-    # Create a study
-    When I create a study with INVALID,ACCESSION for accession
-    Then the response code should be 400
+    When I attempt to create a study with INVALID,ACCESSION for accession
+    Then the response code should be 4xx


### PR DESCRIPTION
* Enforce validation of accession; don't allow comma or dot symbols
* Update documentation to clarify that comma is not accepted in accession
* Add a test case for not allowing invalid study accessions